### PR TITLE
fix(armours-atlas): add missing 'espoir' value for the berzerk 350 and 500PG evolutions

### DIFF
--- a/_packs_sources/armours-atlas/Berserk_34ca401ec8ca57e0.json
+++ b/_packs_sources/armours-atlas/Berserk_34ca401ec8ca57e0.json
@@ -4224,7 +4224,7 @@
             "armure": 0,
             "champDeForce": 0,
             "energie": 0,
-            "espoir": null
+            "espoir": 25
           }
         },
         "2": {
@@ -4477,7 +4477,7 @@
             "armure": 0,
             "champDeForce": 0,
             "energie": 0,
-            "espoir": null
+            "espoir": 25
           }
         }
       },


### PR DESCRIPTION
Hello,

Petite erreur détécté par un de nos joueurs passant sur l'armure Berzerk.
Lorsque l'on active l'évolution 350PG, le joueur perd les 25 points d'espoir bonus (base 15 + 10 évolution) accordé par l'évolution 250PG.
Même soucis avec l'évolution 500PG.