### PR TITLE
fix(weapons-rare): change 'Pavois - Charge' to be of 'contact' type

### DIFF
--- a/_packs_sources/weapons-rare/Pavois___Charge_702494ff2b36336f.json
+++ b/_packs_sources/weapons-rare/Pavois___Charge_702494ff2b36336f.json
@@ -5,7 +5,7 @@
   "system": {
     "description": "<p>Le pavois est le plus grand bouclier du Knight. Il dispose d'un générateur de champ si efficace qu'il est capable de repousser le sol. Gauvain lui a trouvé deux usages. Premièrement, le champ de force du pavois dévie la plupart des attaques. Deuxièmement, quand il est surchargé en énergie, le pavois dévie l'air si fort qu'il génère une aspiration devant lui. Le chevalier, tiré vers l'avant peut faire une charge particulièrement violente à même de sonner la plus résistante des horreurs.\nEffectuer une charge coûte une action de déplacement normale qui se termine par un gros choc sur la cible visée. Une charge ne peut pas être effectuée par un chevalier déjà au combat au contact.</p>\n",
     "rarete": "rare",
-    "type": "distance",
+    "type": "contact",
     "portee": "courte",
     "prix": 60,
     "energie": 0,


### PR DESCRIPTION
This will fix force not being applied twice as expected by 'Lesté', and allow strutural enhancements like 'Protectrice' to work properly.

ref. [Discord](https://discord.com/channels/715943353409339425/1032316487366611055/1222503369655193610)