### PR TITLE
Correction Warlock / Pod Missile / Pod Roquette

### DIFF
--- a/_packs_sources/armours-atlas/Warlock_c1f1193feb1f4192.json
+++ b/_packs_sources/armours-atlas/Warlock_c1f1193feb1f4192.json
@@ -3778,7 +3778,7 @@
               },
               "relance": {
                 "label": "",
-                "value": false
+                "value": true
               },
               "maxeffets": {
                 "label": "",

--- a/_packs_sources/modules-avance/Pod_missile_qme9vLEL1w2LbQVu.json
+++ b/_packs_sources/modules-avance/Pod_missile_qme9vLEL1w2LbQVu.json
@@ -21,7 +21,7 @@
       ],
       "details": {
         "n1": {
-          "permanent": false,
+          "permanent": true,
           "rarete": "avance",
           "prix": 30,
           "energie": {
@@ -199,6 +199,7 @@
             "has": true,
             "type": "distance",
             "portee": "longue",
+            "energie":1,
             "optionsmunitions": {
               "has": false,
               "actuel": "0",

--- a/_packs_sources/modules-avance/Pod_roquette_aACLT8HUfdaY7j3E.json
+++ b/_packs_sources/modules-avance/Pod_roquette_aACLT8HUfdaY7j3E.json
@@ -23,7 +23,7 @@
       ],
       "details": {
         "n1": {
-          "permanent": false,
+          "permanent": true,
           "rarete": "avance",
           "prix": 30,
           "energie": {
@@ -201,6 +201,7 @@
             "has": true,
             "type": "distance",
             "portee": "longue",
+            "energie":1,
             "optionsmunitions": {
               "has": false,
               "actuel": "0",
@@ -425,7 +426,7 @@
           }
         },
         "n2": {
-          "permanent": false,
+          "permanent": true,
           "rarete": "avance",
           "prix": 20,
           "energie": {
@@ -624,6 +625,7 @@
             "has": true,
             "type": "distance",
             "portee": "longue",
+            "energie":1,
             "degats": {
               "dice": 1,
               "fixe": 6,
@@ -854,7 +856,7 @@
           }
         },
         "n3": {
-          "permanent": false,
+          "permanent": true,
           "rarete": "rare",
           "prix": 30,
           "energie": {
@@ -1053,6 +1055,7 @@
             "has": true,
             "type": "distance",
             "portee": "longue",
+            "energie":1,
             "degats": {
               "dice": 1,
               "fixe": 6,


### PR DESCRIPTION
- Correction de l'évolution à 250PG de la Warlock n'ayant pas la relance du Contrecoups.
- Correction du Pod Roquette et du Pod Missile qui passent en permanent et qui ont un coût par attaque de 1 PE à présent.